### PR TITLE
Fix a failure when running rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,6 @@
-#!/usr/bin/env rake
-require 'bundler/setup'
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
-begin
-  require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec)
 
-  RSpec::Core::RakeTask.new(:spec)
-
-  task :default => :spec
-rescue LoadError
-end
+task default: :spec

--- a/rspec-rebound.gemspec
+++ b/rspec-rebound.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "rspec-core", "~> 3.3"
   gem.add_development_dependency "rspec", "~> 3.3"
   gem.add_development_dependency "debug", "~> 1.0"
+  gem.add_development_dependency "rake", "~> 13.0"
 end


### PR DESCRIPTION
```
❯ bundle exec rake             
bundler: failed to load command: rake (/Users/ydah/.rbenv/versions/3.5-dev/bin/rake)
```